### PR TITLE
Mage Core Template Block

### DIFF
--- a/app/code/core/Mage/Core/Block/Template.php
+++ b/app/code/core/Mage/Core/Block/Template.php
@@ -237,6 +237,11 @@ HTML;
 
         try {
             $includeFilePath = realpath($this->_viewDir . DS . $fileName);
+            
+            if (empty($includeFilePath)) {
+                throw new RuntimeException('Missing template file: ' . $fileName);
+            }
+            
             if (strpos($includeFilePath, realpath($this->_viewDir)) === 0 || $this->_getAllowSymlinks()) {
                 include $includeFilePath;
             } else {


### PR DESCRIPTION
implemented exception when include file path is empty (with attempting template name)